### PR TITLE
Add support to frameworkextrabundle 3.0

### DIFF
--- a/src/Ofertix/SecurityExtraBundle/ParamConverter/UserParamConverter.php
+++ b/src/Ofertix/SecurityExtraBundle/ParamConverter/UserParamConverter.php
@@ -18,7 +18,7 @@ class UserParamConverter implements ParamConverterInterface
         $this->securityContext = $securityContext;
     }
 
-    public function apply(Request $request, ConfigurationInterface $configuration)
+    public function apply(Request $request, ParamConverter $configuration)
     {
         /** @var $configuration ParamConverter */
         $user = $this->securityContext->getToken()->getUser();
@@ -29,8 +29,8 @@ class UserParamConverter implements ParamConverterInterface
         }
     }
 
-    public function supports(ConfigurationInterface $configuration)
+    public function supports(ParamConverter $configuration)
     {
-        return $configuration instanceof ParamConverter && $configuration->getName() === 'user';
+        return $configuration->getName() === 'user';
     }
 }


### PR DESCRIPTION
FrameworkExtraBundle 3.0 has changed the interface of paramconverter. One has to be carefull with merging this PR because it breaks backward compatibility.
